### PR TITLE
Update to 1.18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.18
       id: go
 
     - name: Check out code into the Go module directory


### PR DESCRIPTION
causing the release build to fail. needed to bump this to 1.18.
https://github.com/expel-io/aws-resource-counter/actions/runs/3857930337/jobs/6575878298