### PR TITLE
[adhoc] Fixing some linter issues

### DIFF
--- a/containers_test.go
+++ b/containers_test.go
@@ -38,48 +38,40 @@ var taskDefinitionsPerRegion = map[string]*TaskInfo{
 	// definition uses one container, with a single image. The third task has a single container
 	// but uses the same image as the first task. In total, there are 3 task definitions, 4
 	// containers, but with only 3 unique container images.
-	"us-east-1": &TaskInfo{
+	"us-east-1": {
 		ListOutputs: []*ecs.ListTaskDefinitionsOutput{
-			&ecs.ListTaskDefinitionsOutput{
+			{
 				TaskDefinitionArns: []*string{
 					aws.String("some-long-name:task-definition/family:1"),
 					aws.String("some-long-name:task-definition/family:2"),
 				},
 			},
-			&ecs.ListTaskDefinitionsOutput{
+			{
 				TaskDefinitionArns: []*string{
 					aws.String("some-long-name:task-definition/otherfamily:1"),
 				},
 			},
 		},
 		DescribeOutputMap: map[string]*ecs.DescribeTaskDefinitionOutput{
-			"some-long-name:task-definition/family:1": &ecs.DescribeTaskDefinitionOutput{
+			"some-long-name:task-definition/family:1": {
 				TaskDefinition: &ecs.TaskDefinition{
 					ContainerDefinitions: []*ecs.ContainerDefinition{
-						&ecs.ContainerDefinition{
-							Image: aws.String("image1"),
-						},
-						&ecs.ContainerDefinition{
-							Image: aws.String("image2"),
-						},
+						{Image: aws.String("image1")},
+						{Image: aws.String("image2")},
 					},
 				},
 			},
-			"some-long-name:task-definition/family:2": &ecs.DescribeTaskDefinitionOutput{
+			"some-long-name:task-definition/family:2": {
 				TaskDefinition: &ecs.TaskDefinition{
 					ContainerDefinitions: []*ecs.ContainerDefinition{
-						&ecs.ContainerDefinition{
-							Image: aws.String("image3"),
-						},
+						{Image: aws.String("image3")},
 					},
 				},
 			},
-			"some-long-name:task-definition/otherfamily:1": &ecs.DescribeTaskDefinitionOutput{
+			"some-long-name:task-definition/otherfamily:1": {
 				TaskDefinition: &ecs.TaskDefinition{
 					ContainerDefinitions: []*ecs.ContainerDefinition{
-						&ecs.ContainerDefinition{
-							Image: aws.String("image1"),
-						},
+						{Image: aws.String("image1")},
 					},
 				},
 			},
@@ -89,9 +81,9 @@ var taskDefinitionsPerRegion = map[string]*TaskInfo{
 	// to the caller. There are two task definitions. Each has a single container image, which
 	// are different. In total, there are 2 task definitions, 2 cotnainers and 2 unique container
 	// images.
-	"us-east-2": &TaskInfo{
+	"us-east-2": {
 		ListOutputs: []*ecs.ListTaskDefinitionsOutput{
-			&ecs.ListTaskDefinitionsOutput{
+			{
 				TaskDefinitionArns: []*string{
 					aws.String("some-long-name:task-definition/family:1"),
 					aws.String("some-long-name:task-definition/anotherfamily:1"),
@@ -99,19 +91,19 @@ var taskDefinitionsPerRegion = map[string]*TaskInfo{
 			},
 		},
 		DescribeOutputMap: map[string]*ecs.DescribeTaskDefinitionOutput{
-			"some-long-name:task-definition/family:1": &ecs.DescribeTaskDefinitionOutput{
+			"some-long-name:task-definition/family:1": {
 				TaskDefinition: &ecs.TaskDefinition{
 					ContainerDefinitions: []*ecs.ContainerDefinition{
-						&ecs.ContainerDefinition{
+						{
 							Image: aws.String("image2"),
 						},
 					},
 				},
 			},
-			"some-long-name:task-definition/anotherfamily:1": &ecs.DescribeTaskDefinitionOutput{
+			"some-long-name:task-definition/anotherfamily:1": {
 				TaskDefinition: &ecs.TaskDefinition{
 					ContainerDefinitions: []*ecs.ContainerDefinition{
-						&ecs.ContainerDefinition{
+						{
 							Image: aws.String("image4"),
 						},
 					},
@@ -120,17 +112,17 @@ var taskDefinitionsPerRegion = map[string]*TaskInfo{
 		},
 	},
 	// AF-SOUTH-1 indicates that no tasks were defined for this regino.
-	"af-south-1": &TaskInfo{
+	"af-south-1": {
 		ListOutputs: []*ecs.ListTaskDefinitionsOutput{
-			&ecs.ListTaskDefinitionsOutput{},
+			{},
 		},
 	},
 	// AF-SOUTH-2 simulates a flawed case--what would happen if DescribeTaskDefinition
 	// ever returned a failure? We simulate that by indicating that there is a Task Definition
 	// ARN for which there is no description.
-	"af-south-2": &TaskInfo{
+	"af-south-2": {
 		ListOutputs: []*ecs.ListTaskDefinitionsOutput{
-			&ecs.ListTaskDefinitionsOutput{
+			{
 				TaskDefinitionArns: []*string{
 					aws.String("this-is-a-non-existent-task-arn-which-triggers-failure"),
 				},

--- a/ebs_test.go
+++ b/ebs_test.go
@@ -24,7 +24,7 @@ import (
 var ebsVolumesPerRegion = map[string][]*ec2.DescribeVolumesOutput{
 	// US-EAST-1 illustrates a case where DescribeVolumesPages returns 1 page
 	// of results: 3 volumes, but only 2 are attached.
-	"us-east-1": []*ec2.DescribeVolumesOutput{
+	"us-east-1": {
 		&ec2.DescribeVolumesOutput{
 			Volumes: []*ec2.Volume{
 				{
@@ -50,7 +50,7 @@ var ebsVolumesPerRegion = map[string][]*ec2.DescribeVolumesOutput{
 
 	// US-EAST-2 has 1 page of data: 7 Volumes in 3 reservations (1 spot
 	// and 1 scheduled instance mixed in).
-	"us-east-2": []*ec2.DescribeVolumesOutput{
+	"us-east-2": {
 		&ec2.DescribeVolumesOutput{
 			Volumes: []*ec2.Volume{},
 		},
@@ -60,7 +60,7 @@ var ebsVolumesPerRegion = map[string][]*ec2.DescribeVolumesOutput{
 	// simulate the case when DescribeVolumesPages returns three pages of
 	// results. First page has 3 (all attached), second page has 3 (2 attached)
 	// and the third page has 1 (attached).
-	"af-south-1": []*ec2.DescribeVolumesOutput{
+	"af-south-1": {
 		&ec2.DescribeVolumesOutput{
 			Volumes: []*ec2.Volume{
 				{

--- a/ec2_test.go
+++ b/ec2_test.go
@@ -28,15 +28,15 @@ import (
 // This is our list of accessible regions for the purpose of unit testing.
 var ec2Regions *ec2.DescribeRegionsOutput = &ec2.DescribeRegionsOutput{
 	Regions: []*ec2.Region{
-		&ec2.Region{
+		{
 			OptInStatus: aws.String("opt-in-not-required"),
 			RegionName:  aws.String("us-east-1"),
 		},
-		&ec2.Region{
+		{
 			OptInStatus: aws.String("opt-in-not-required"),
 			RegionName:  aws.String("us-east-2"),
 		},
-		&ec2.Region{
+		{
 			OptInStatus: aws.String("opted-in"),
 			RegionName:  aws.String("af-south-1"),
 		},
@@ -52,26 +52,26 @@ var ec2InstancesPerRegion = map[string][]*ec2.DescribeInstancesOutput{
 	// US-EAST-1 illustrates a case where DescribeInstancesPages returns two pages of results.
 	// First page: 2 different reservations (1 running instance, then 2 instances [1 is spot])
 	// Second page: 1 reservation (2 instances, 1 of which is stopped)
-	"us-east-1": []*ec2.DescribeInstancesOutput{
+	"us-east-1": {
 		&ec2.DescribeInstancesOutput{
 			Reservations: []*ec2.Reservation{
-				&ec2.Reservation{
+				{
 					Instances: []*ec2.Instance{
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
 						},
 					},
 				},
-				&ec2.Reservation{
+				{
 					Instances: []*ec2.Instance{
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
 						},
-						&ec2.Instance{
+						{
 							InstanceLifecycle: aws.String("spot"),
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
@@ -83,14 +83,14 @@ var ec2InstancesPerRegion = map[string][]*ec2.DescribeInstancesOutput{
 		},
 		&ec2.DescribeInstancesOutput{
 			Reservations: []*ec2.Reservation{
-				&ec2.Reservation{
+				{
 					Instances: []*ec2.Instance{
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("stopped"),
 							},
 						},
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
@@ -102,59 +102,59 @@ var ec2InstancesPerRegion = map[string][]*ec2.DescribeInstancesOutput{
 	},
 	// US-EAST-2 has 1 page of data: 7 instances in 3 reservations (1 spot
 	// and 1 scheduled instance mixed in).
-	"us-east-2": []*ec2.DescribeInstancesOutput{
+	"us-east-2": {
 		&ec2.DescribeInstancesOutput{
 			Reservations: []*ec2.Reservation{
-				&ec2.Reservation{
+				{
 					Instances: []*ec2.Instance{
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("stopped"),
 							},
 						},
-						&ec2.Instance{
+						{
 							InstanceLifecycle: aws.String("scheduled"),
 						},
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
 						},
 					},
 				},
-				&ec2.Reservation{
+				{
 					Instances: []*ec2.Instance{
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
 						},
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
 						},
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("stopped"),
 							},
 						},
 					},
 				},
-				&ec2.Reservation{
+				{
 					Instances: []*ec2.Instance{
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
 						},
-						&ec2.Instance{
+						{
 							InstanceLifecycle: aws.String("spot"),
 							State: &ec2.InstanceState{
 								Name: aws.String("stopped"),
 							},
 						},
-						&ec2.Instance{
+						{
 							State: &ec2.InstanceState{
 								Name: aws.String("running"),
 							},
@@ -166,7 +166,7 @@ var ec2InstancesPerRegion = map[string][]*ec2.DescribeInstancesOutput{
 	},
 	// AF-SOUTH-1 is an "opted in" region (Cape Town, Africa). We are going to
 	// simply indicate that no instances exist here.
-	"af-south-1": []*ec2.DescribeInstancesOutput{
+	"af-south-1": {
 		&ec2.DescribeInstancesOutput{},
 	},
 }
@@ -263,7 +263,6 @@ func resolvePathByReflection(reflectStruct reflect.Value, fieldPath []string) (s
 			} else {
 				return "", false
 			}
-			break
 		}
 	}
 

--- a/lambda_test.go
+++ b/lambda_test.go
@@ -25,24 +25,24 @@ import (
 var lambdaFnsPerRegion = map[string][]*lambda.ListFunctionsOutput{
 	// US-EAST-1 illustrates a case where ListFunctionsPages returns 1
 	// page of 4 results
-	"us-east-1": []*lambda.ListFunctionsOutput{
+	"us-east-1": {
 		&lambda.ListFunctionsOutput{
 			Functions: []*lambda.FunctionConfiguration{
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
+				{},
+				{},
+				{},
+				{},
 			},
 		},
 	},
 	// US-EAST-2 illustrates a case where ListFunctionsPages returns 1 page of
 	// 3 results
-	"us-east-2": []*lambda.ListFunctionsOutput{
+	"us-east-2": {
 		&lambda.ListFunctionsOutput{
 			Functions: []*lambda.FunctionConfiguration{
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
+				{},
+				{},
+				{},
 			},
 		},
 	},
@@ -50,23 +50,23 @@ var lambdaFnsPerRegion = map[string][]*lambda.ListFunctionsOutput{
 	// of results.
 	// First page: 9 functions
 	// Second page: 1 functions
-	"af-south-1": []*lambda.ListFunctionsOutput{
+	"af-south-1": {
 		&lambda.ListFunctionsOutput{
 			Functions: []*lambda.FunctionConfiguration{
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
-				&lambda.FunctionConfiguration{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
+				{},
 			},
 		},
 		&lambda.ListFunctionsOutput{
 			Functions: []*lambda.FunctionConfiguration{
-				&lambda.FunctionConfiguration{},
+				{},
 			},
 		},
 	},

--- a/lightsail_test.go
+++ b/lightsail_test.go
@@ -24,13 +24,13 @@ import (
 // This is our list of accessible regions for the purpose of unit testing.
 var lightsailRegions *lightsail.GetRegionsOutput = &lightsail.GetRegionsOutput{
 	Regions: []*lightsail.Region{
-		&lightsail.Region{
+		{
 			Name: aws.String("us-east-1"),
 		},
-		&lightsail.Region{
+		{
 			Name: aws.String("us-east-2"),
 		},
-		&lightsail.Region{
+		{
 			Name: aws.String("eu-west-1"),
 		},
 	},
@@ -40,21 +40,21 @@ var lightsailRegions *lightsail.GetRegionsOutput = &lightsail.GetRegionsOutput{
 var lightsailInstancesPerRegion = map[string]*lightsail.GetInstancesOutput{
 	// US-EAST-1 simulates a region where there are three Lightsail instances:
 	// one is Wordpress, one is Magento (but it is stopped) and the other is Node.js.
-	"us-east-1": &lightsail.GetInstancesOutput{
+	"us-east-1": {
 		Instances: []*lightsail.Instance{
-			&lightsail.Instance{
+			{
 				Name: aws.String("WordPress-1"),
 				State: &lightsail.InstanceState{
 					Name: aws.String("running"),
 				},
 			},
-			&lightsail.Instance{
+			{
 				Name: aws.String("Magento-1"),
 				State: &lightsail.InstanceState{
 					Name: aws.String("pending"),
 				},
 			},
-			&lightsail.Instance{
+			{
 				Name: aws.String("Node-js-1"),
 				State: &lightsail.InstanceState{
 					Name: aws.String("running"),
@@ -63,18 +63,18 @@ var lightsailInstancesPerRegion = map[string]*lightsail.GetInstancesOutput{
 		},
 	},
 	// US-EAST-2 has no instances...
-	"us-east-2": &lightsail.GetInstancesOutput{},
+	"us-east-2": {},
 
 	// EU-WEST-1 has 2 instances (only 1 running)
-	"eu-west-1": &lightsail.GetInstancesOutput{
+	"eu-west-1": {
 		Instances: []*lightsail.Instance{
-			&lightsail.Instance{
+			{
 				Name: aws.String("WordPress-1"),
 				State: &lightsail.InstanceState{
 					Name: aws.String("running"),
 				},
 			},
-			&lightsail.Instance{
+			{
 				Name: aws.String("Magento-1"),
 				State: &lightsail.InstanceState{
 					Name: aws.String("stopped"),

--- a/rds_test.go
+++ b/rds_test.go
@@ -27,44 +27,44 @@ import (
 var rdsInstancesPerRegion = map[string][]*rds.DescribeDBInstancesOutput{
 	// US-EAST-1 illustrates a case where DescribeDBInstancesPages returns 1
 	// page of NO results
-	"us-east-1": []*rds.DescribeDBInstancesOutput{
+	"us-east-1": {
 		&rds.DescribeDBInstancesOutput{},
 	},
 	// US-EAST-2 illustrates a case where DescribeDBInstancesPages returns two pages of results.
 	// First page: 5 instances, 3 are available
 	// Second page: 4 instances, 2 are available
-	"us-east-2": []*rds.DescribeDBInstancesOutput{
+	"us-east-2": {
 		&rds.DescribeDBInstancesOutput{
 			DBInstances: []*rds.DBInstance{
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("available"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("backing-up"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("available"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("creating"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("available"),
 				},
 			},
 		},
 		&rds.DescribeDBInstancesOutput{
 			DBInstances: []*rds.DBInstance{
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("stopped"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("available"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("stopping"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("available"),
 				},
 			},
@@ -72,16 +72,16 @@ var rdsInstancesPerRegion = map[string][]*rds.DescribeDBInstancesOutput{
 	},
 	// AF-SOUTH-1 is an "opted in" region (Cape Town, Africa). We are going to
 	// simply indicate that 3 instance exists here (only 1 running).
-	"af-south-1": []*rds.DescribeDBInstancesOutput{
+	"af-south-1": {
 		&rds.DescribeDBInstancesOutput{
 			DBInstances: []*rds.DBInstance{
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("upgrading"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("available"),
 				},
-				&rds.DBInstance{
+				{
 					DBInstanceStatus: aws.String("backtracking"),
 				},
 			},


### PR DESCRIPTION
these were just linter problems and how i understood them (please let me know if i'm wrong at all):
- redundant type from array, slice, or map composite literal: i think this means that since we are already declaring the type in a composite literal, we don't need to redeclare the type for each value. ex:

warning:
```
var m = map[string]*TaskInfo{
   "key1": &TaskInfo{}
}
```
ok:
```
var m = map[string]*TaskInfo{
   "key1": {}
}
```
- redundant break statement (S1023): for this, switch statements already break at the selected case, so it's unnecessary to add a break statement at the end of a case