### PR TITLE
Updating Dockerfiles and go.mod to golang 1.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/expel-io/aws-resource-counter
 
-go 1.18
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.44.213

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=


### PR DESCRIPTION
Hello!

The Developer Experience team has created this pull request to help you upgrade Go from version 1.17, 1.18, or 1.19 to 1.21. Go versions before 1.20 are end of life and are no longer receiving any security updates. At your earliest convenience please verify that this PR doesn't break your application and upgrade Go to 1.21. This is related to [Orianna's post in Engineering](https://expletives.slack.com/archives/C0103UGR31T/p1706281043257539) in Slack.

We wrote a script to update all Dockerfiles and docker-compose files in the repo to use the go-1.21-build base image instead of older Go build images. We also searched the repo for all `go.mod` files and ran `go mod edit -go=1.21` then `go mod tidy` in each directory where we found `go.mod`.