### PR TITLE
GROW-556: Update go (v1.18 -> v1.21)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.18.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest, macos-latest]
 
     name: Build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.21
       id: go
 
     - name: Check out code into the Go module directory

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ If you are using MacOS Catalina, there is a stricter process for running binarie
 
 You can also build this utility directly from source. We have built and tested this with the following Go versions:
 
-* v1.18
+* v1.21
 
 To run from source, use the following command line:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/expel-io/aws-resource-counter
 
-go 1.18
+go 1.21
 
 require (
 	github.com/aws/aws-sdk-go v1.44.213

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/text v0.4.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
+golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20191119224855-298f0cb1881e/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/tools v0.1.12/go.mod h1:hNGJHUnrk76NpqgfD5Aqm5Crs+Hm0VOH/i9J2+nxYbc=


### PR DESCRIPTION
Updating go version to 1.21. This PR also includes updating the version of go used to create the build artifacts in releases. 

Tested the go version updates with the below command:
```
liamaverion@LAVERION-584 aws-resource-counter % go build .
liamaverion@LAVERION-584 aws-resource-counter % go test
PASS
ok      github.com/expel-io/aws-resource-counter        1.009s
liamaverion@LAVERION-584 aws-resource-counter % ./aws-resource-counter --profile resource-counter-test
Cloud Resource Counter (v?.?.?) running with:
 o AWS Profile: resource-counter-test
 o AWS Region:  (All regions supported by this account)
 o Output file: resources.csv

Activity
 * Retrieving Account ID...OK (211249992032)
 * Retrieving EC2 counts....................OK (7)
 * Retrieving Spot instance counts....................OK (0)
 * Retrieving EBS volume counts....................OK (25)
 * Retrieving Unique container counts....................OK (1)
 * Retrieving Lambda function counts....................OK (2)
 * Retrieving RDS instance counts....................OK (1)
 * Retrieving Lightsail instance counts.................OK (0)
 * Retrieving S3 bucket counts...OK (29)
 * Retrieving EKS Node counts....................OK (0)
 * Writing to file...OK

Success.
```

Verified the numbers returned for this specific account also matched with the numbers through the browser.